### PR TITLE
urls.defaults is no longer correct django import path

### DIFF
--- a/dart/urls.py
+++ b/dart/urls.py
@@ -1,4 +1,4 @@
-from coffin.conf.urls.defaults import *
+from coffin.conf.urls import patterns, url
 
 urlpatterns = patterns("dart.views",
 


### PR DESCRIPTION
Supporting Django 1.8 upgrade
